### PR TITLE
엔티티 보일러 플레이트 코드 추상화 완료

### DIFF
--- a/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatBlackList.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatBlackList.java
@@ -1,36 +1,34 @@
 package com.prgrmsfinal.skypedia.chat.entity;
 
 import com.prgrmsfinal.skypedia.chat.entity.compositekey.ChatBlackListId;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ChatBlackList {
-    @EmbeddedId
-    private ChatBlackListId id;
-
+public class ChatBlackList extends AbstractAssociationEntity<ChatBlackListId, Member, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("memberId")
-    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("targetId")
-    @JoinColumn(name = "target_id", referencedColumnName = "id")
+    @JoinColumn(name = "target_id", referencedColumnName = "id", nullable = false)
     private Member target;
-
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
 
     @Builder
     public ChatBlackList(Member member, Member target) {
-        this.id = new ChatBlackListId(member.getId(), target.getId());
+        super.initializeId(member, target);
         this.member = member;
         this.target = target;
+    }
+
+    @Override
+    protected ChatBlackListId createId(Member member, Member target) {
+        return new ChatBlackListId(member.getId(), target.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatMessageRead.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatMessageRead.java
@@ -1,36 +1,34 @@
 package com.prgrmsfinal.skypedia.chat.entity;
 
 import com.prgrmsfinal.skypedia.chat.entity.compositekey.ChatMessageReadId;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ChatMessageRead {
-    @EmbeddedId
-    private ChatMessageReadId id;
-
+public class ChatMessageRead extends AbstractAssociationEntity<ChatMessageReadId, ChatMessage, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("chatMessageId")
-    @JoinColumn(name = "chat_message_id", referencedColumnName = "id")
+    @JoinColumn(name = "chat_message_id", referencedColumnName = "id", nullable = false)
     private ChatMessage chatMessage;
 
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("memberId")
-    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
-
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
 
     @Builder
     public ChatMessageRead(ChatMessage chatMessage, Member member) {
-        this.id = new ChatMessageReadId(chatMessage.getId(), member.getId());
+        super.initializeId(chatMessage, member);
         this.chatMessage = chatMessage;
         this.member = member;
+    }
+
+    @Override
+    protected ChatMessageReadId createId(ChatMessage chatMessage, Member member) {
+        return new ChatMessageReadId(chatMessage.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/chat/entity/ChatParticipant.java
@@ -1,6 +1,7 @@
 package com.prgrmsfinal.skypedia.chat.entity;
 
 import com.prgrmsfinal.skypedia.chat.entity.compositekey.ChatParticipantId;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,10 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ChatParticipant {
-    @EmbeddedId
-    private ChatParticipantId id;
-
+public class ChatParticipant extends AbstractAssociationEntity<ChatParticipantId, ChatRoom, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("chatRoomId")
     @JoinColumn(name = "chat_room_id", referencedColumnName = "id")
@@ -24,13 +22,15 @@ public class ChatParticipant {
     @JoinColumn(name = "member_id", referencedColumnName = "id")
     private Member member;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public ChatParticipant(ChatRoom chatRoom, Member member) {
-        this.id = new ChatParticipantId(chatRoom.getId(), member.getId());
+        super.initializeId(chatRoom, member);
         this.chatRoom = chatRoom;
         this.member = member;
+    }
+
+    @Override
+    protected ChatParticipantId createId(ChatRoom chatRoom, Member member) {
+        return new ChatParticipantId(chatRoom.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/global/entity/AbstractAssociationEntity.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/global/entity/AbstractAssociationEntity.java
@@ -1,0 +1,27 @@
+package com.prgrmsfinal.skypedia.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class AbstractAssociationEntity<ID extends Serializable, E1, E2> {
+    @EmbeddedId
+    protected ID id;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    protected abstract ID createId(E1 entity1, E2 entity2);
+
+    protected void initializeId(E1 entity1, E2 entity2) {
+        this.id = createId(entity1, entity2);
+    }
+}

--- a/src/main/java/com/prgrmsfinal/skypedia/global/entity/AbstractMetricsEntity.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/global/entity/AbstractMetricsEntity.java
@@ -1,0 +1,33 @@
+package com.prgrmsfinal.skypedia.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class AbstractMetricsEntity {
+    @Id
+    protected Long id;
+
+    @Column(nullable = false)
+    protected Long viewCount;
+
+    @Column(nullable = false)
+    protected Long likeCount;
+
+    protected AbstractMetricsEntity(Long id) {
+        this.id = id;
+        this.viewCount = 0L;
+        this.likeCount = 0L;
+    }
+
+    protected void refresh(Long viewCount, Long likeCount) {
+        this.viewCount += viewCount;
+        this.likeCount += likeCount;
+    }
+}

--- a/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagPlanPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagPlanPost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.hashtag.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.hashtag.entity.compositekey.HashtagPlanPostId;
 import com.prgrmsfinal.skypedia.planpost.entity.PlanPost;
 import jakarta.persistence.*;
@@ -13,10 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class HashtagPlanPost {
-    @EmbeddedId
-    private HashtagPlanPostId id;
-
+public class HashtagPlanPost extends AbstractAssociationEntity<HashtagPlanPostId, Hashtag, PlanPost> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("hashtagId")
     @JoinColumn(name = "hashtag_id", referencedColumnName = "id", nullable = false)
@@ -27,13 +25,15 @@ public class HashtagPlanPost {
     @JoinColumn(name = "plan_post_id", referencedColumnName = "id", nullable = false)
     private PlanPost planPost;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public HashtagPlanPost(Hashtag hashtag, PlanPost planPost) {
-        this.id = new HashtagPlanPostId(hashtag.getId(), planPost.getId());
+        super.initializeId(hashtag, planPost);
         this.hashtag = hashtag;
         this.planPost = planPost;
+    }
+
+    @Override
+    protected HashtagPlanPostId createId(Hashtag hashtag, PlanPost planPost) {
+        return new HashtagPlanPostId(hashtag.getId(), planPost.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagPost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.hashtag.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.hashtag.entity.compositekey.HashtagPostId;
 import com.prgrmsfinal.skypedia.post.entity.Post;
 import jakarta.persistence.*;
@@ -13,10 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class HashtagPost {
-    @EmbeddedId
-    private HashtagPostId id;
-
+public class HashtagPost extends AbstractAssociationEntity<HashtagPostId, Hashtag, Post> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("hashtagId")
     @JoinColumn(name = "hashtag_id", referencedColumnName = "id", nullable = false)
@@ -27,13 +25,15 @@ public class HashtagPost {
     @JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
     private Post post;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public HashtagPost(Hashtag hashtag, Post post) {
-        this.id = new HashtagPostId(hashtag.getId(), post.getId());
+        super.initializeId(hashtag, post);
         this.hashtag = hashtag;
         this.post = post;
+    }
+
+    @Override
+    protected HashtagPostId createId(Hashtag hashtag, Post post) {
+        return new HashtagPostId(hashtag.getId(), post.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagVotePost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/hashtag/entity/HashtagVotePost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.hashtag.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.hashtag.entity.compositekey.HashtagVotePostId;
 import com.prgrmsfinal.skypedia.votepost.entity.VotePost;
 import jakarta.persistence.*;
@@ -13,10 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class HashtagVotePost {
-    @EmbeddedId
-    private HashtagVotePostId id;
-
+public class HashtagVotePost extends AbstractAssociationEntity<HashtagVotePostId, Hashtag, VotePost> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("hashtagId")
     @JoinColumn(name = "hashtag_id", referencedColumnName = "id", nullable = false)
@@ -27,13 +25,15 @@ public class HashtagVotePost {
     @JoinColumn(name = "vote_post_id", referencedColumnName = "id", nullable = false)
     private VotePost votePost;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public HashtagVotePost(Hashtag hashtag, VotePost votePost) {
-        this.id = new HashtagVotePostId(hashtag.getId(), votePost.getId());
+        super.initializeId(hashtag, votePost);
         this.hashtag = hashtag;
         this.votePost = votePost;
+    }
+
+    @Override
+    protected HashtagVotePostId createId(Hashtag hashtag, VotePost votePost) {
+        return new HashtagVotePostId(hashtag.getId(), votePost.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/notify/entity/NotifyViewer.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/notify/entity/NotifyViewer.java
@@ -1,9 +1,11 @@
 package com.prgrmsfinal.skypedia.notify.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.notify.entity.compositekey.NotifyViewerId;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,10 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class NotifyViewer {
-    @Id
-    private NotifyViewerId id;
-
+public class NotifyViewer extends AbstractAssociationEntity<NotifyViewerId, NotifyMessage, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("notifyMessageId")
     @JoinColumn(name = "notify_message_id", referencedColumnName = "id", nullable = false)
@@ -29,10 +28,19 @@ public class NotifyViewer {
     @Column(nullable = false)
     private boolean viewed;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     private LocalDateTime viewedAt;
+
+    @Builder
+    public NotifyViewer(NotifyMessage notifyMessage, Member member) {
+        super.initializeId(notifyMessage, member);
+        this.notifyMessage = notifyMessage;
+        this.member = member;
+    }
+
+    @Override
+    protected NotifyViewerId createId(NotifyMessage notifyMessage, Member member) {
+        return new NotifyViewerId(notifyMessage.getId(), member.getId());
+    }
 
     public void markAsViewed() {
         this.viewed = true;

--- a/src/main/java/com/prgrmsfinal/skypedia/notify/entity/compositekey/NotifyViewerId.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/notify/entity/compositekey/NotifyViewerId.java
@@ -2,13 +2,14 @@ package com.prgrmsfinal.skypedia.notify.entity.compositekey;
 
 import jakarta.persistence.Embeddable;
 import lombok.*;
+import java.io.Serializable;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class NotifyViewerId {
+public class NotifyViewerId implements Serializable {
     private Long notifyMessageId;
 
     private Long memberId;

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoChatMessage.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoChatMessage.java
@@ -1,19 +1,15 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
 import com.prgrmsfinal.skypedia.chat.entity.ChatMessage;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoChatMessageId;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoChatMessage {
-    @EmbeddedId
-    private PhotoChatMessageId id;
-
+public class PhotoChatMessage extends AbstractAssociationEntity<PhotoChatMessageId, Photo, ChatMessage> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -24,13 +20,15 @@ public class PhotoChatMessage {
     @JoinColumn(name = "chat_message_id", referencedColumnName = "id", nullable = false)
     private ChatMessage chatMessage;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoChatMessage(Photo photo, ChatMessage chatMessage) {
-        this.id = new PhotoChatMessageId(photo.getId(), chatMessage.getId());
+        super.initializeId(photo, chatMessage);
         this.photo = photo;
         this.chatMessage = chatMessage;
+    }
+
+    @Override
+    protected PhotoChatMessageId createId(Photo photo, ChatMessage chatMessage) {
+        return new PhotoChatMessageId(photo.getId(), chatMessage.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPlanPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPlanPost.java
@@ -1,18 +1,15 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoPlanPostId;
 import com.prgrmsfinal.skypedia.planpost.entity.PlanPost;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoPlanPost {
-    @EmbeddedId
-    private PhotoPlanPostId id;
-
+public class PhotoPlanPost extends AbstractAssociationEntity<PhotoPlanPostId, Photo, PlanPost> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class PhotoPlanPost {
     @JoinColumn(name = "plan_post_id", referencedColumnName = "id", nullable = false)
     private PlanPost planPost;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoPlanPost(Photo photo, PlanPost planPost) {
-        this.id = new PhotoPlanPostId(photo.getId(), planPost.getId());
+        super.initializeId(photo, planPost);
         this.photo = photo;
         this.planPost = planPost;
+    }
+
+    @Override
+    protected PhotoPlanPostId createId(Photo photo, PlanPost planPost) {
+        return new PhotoPlanPostId(photo.getId(), planPost.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPlanPostItem.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPlanPostItem.java
@@ -1,18 +1,15 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoPlanPostItemId;
 import com.prgrmsfinal.skypedia.planpost.entity.PlanPostItem;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoPlanPostItem {
-    @EmbeddedId
-    private PhotoPlanPostItemId id;
-
+public class PhotoPlanPostItem extends AbstractAssociationEntity<PhotoPlanPostItemId, Photo, PlanPostItem> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class PhotoPlanPostItem {
     @JoinColumn(name = "plan_post_item_id", referencedColumnName = "id", nullable = false)
     private PlanPostItem planPostItem;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoPlanPostItem(Photo photo, PlanPostItem planPostItem) {
-        this.id = new PhotoPlanPostItemId(photo.getId(), planPostItem.getId());
+        super.initializeId(photo, planPostItem);
         this.photo = photo;
         this.planPostItem = planPostItem;
+    }
+
+    @Override
+    protected PhotoPlanPostItemId createId(Photo photo, PlanPostItem planPostItem) {
+        return new PhotoPlanPostItemId(photo.getId(), planPostItem.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoPost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoPostId;
 import com.prgrmsfinal.skypedia.post.entity.Post;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoPost {
-    @EmbeddedId
-    private PhotoPostId id;
-
+public class PhotoPost extends AbstractAssociationEntity<PhotoPostId, Photo, Post> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PhotoPost {
     @JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
     private Post post;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoPost(Photo photo, Post post) {
-        this.id = new PhotoPostId(photo.getId(), post.getId());
+        super.initializeId(photo, post);
         this.photo = photo;
         this.post = post;
+    }
+
+    @Override
+    protected PhotoPostId createId(Photo photo, Post post) {
+        return new PhotoPostId(photo.getId(), post.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoProfile.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoProfile.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoProfileId;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoProfile {
-    @EmbeddedId
-    private PhotoProfileId id;
-
+public class PhotoProfile extends AbstractAssociationEntity<PhotoProfileId, Photo, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PhotoProfile {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoProfile(Photo photo, Member member) {
-        this.id = new PhotoProfileId(photo.getId(), member.getId());
+        super.initializeId(photo, member);
         this.photo = photo;
         this.member = member;
+    }
+
+    @Override
+    protected PhotoProfileId createId(Photo photo, Member member) {
+        return new PhotoProfileId(photo.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoVotePost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoVotePost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoVotePostId;
 import com.prgrmsfinal.skypedia.votepost.entity.VotePost;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoVotePost {
-    @EmbeddedId
-    private PhotoVotePostId id;
-
+public class PhotoVotePost extends AbstractAssociationEntity<PhotoVotePostId, Photo, VotePost> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PhotoVotePost {
     @JoinColumn(name = "vote_post_id", referencedColumnName = "id", nullable = false)
     private VotePost votePost;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoVotePost(Photo photo, VotePost votePost) {
-        this.id = new PhotoVotePostId(photo.getId(), votePost.getId());
+        super.initializeId(photo, votePost);
         this.photo = photo;
         this.votePost = votePost;
+    }
+
+    @Override
+    protected PhotoVotePostId createId(Photo photo, VotePost votePost) {
+        return new PhotoVotePostId(photo.getId(), votePost.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoVotePostItem.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/photo/entity/PhotoVotePostItem.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.photo.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.photo.entity.compositekey.PhotoVotePostItemId;
 import com.prgrmsfinal.skypedia.votepost.entity.VotePostItem;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PhotoVotePostItem {
-    @EmbeddedId
-    private PhotoVotePostItemId id;
-
+public class PhotoVotePostItem extends AbstractAssociationEntity<PhotoVotePostItemId, Photo, VotePostItem> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("photoId")
     @JoinColumn(name = "photo_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PhotoVotePostItem {
     @JoinColumn(name = "vote_post_item_id", referencedColumnName = "id", nullable = false)
     private VotePostItem votePostItem;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PhotoVotePostItem(Photo photo, VotePostItem votePostItem) {
-        this.id = new PhotoVotePostItemId(photo.getId(), votePostItem.getId());
+        super.initializeId(photo, votePostItem);
         this.photo = photo;
         this.votePostItem = votePostItem;
+    }
+
+    @Override
+    protected PhotoVotePostItemId createId(Photo photo, VotePostItem votePostItem) {
+        return new PhotoVotePostItemId(photo.getId(), votePostItem.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostLikes.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostLikes.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.planpost.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.planpost.entity.compositekey.PlanPostLikesId;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PlanPostLikes {
-    @EmbeddedId
-    private PlanPostLikesId id;
-
+public class PlanPostLikes extends AbstractAssociationEntity<PlanPostLikesId, PlanPost, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("planPostId")
     @JoinColumn(name = "plan_post_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PlanPostLikes {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PlanPostLikes(PlanPost planPost, Member member) {
-        this.id = new PlanPostLikesId(planPost.getId(), member.getId());
+        super.initializeId(planPost, member);
         this.planPost = planPost;
         this.member = member;
+    }
+
+    @Override
+    protected PlanPostLikesId createId(PlanPost planPost, Member member) {
+        return new PlanPostLikesId(planPost.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostMetrics.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostMetrics.java
@@ -1,33 +1,13 @@
 package com.prgrmsfinal.skypedia.planpost.entity;
 
-import jakarta.persistence.Column;
+import com.prgrmsfinal.skypedia.global.entity.AbstractMetricsEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Builder;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
-public class PlanPostMetrics {
-    @Id
-    private Long planPostId;
-
-    @Column(nullable = false)
-    private Long viewCount;
-
-    @Column(nullable = false)
-    private Long likeCount;
-
+public class PlanPostMetrics extends AbstractMetricsEntity {
+    @Builder
     public PlanPostMetrics(Long planPostId) {
-        this.planPostId = planPostId;
-        this.viewCount = 0L;
-        this.likeCount = 0L;
-    }
-
-    public void refresh(Long viewCount, Long likeCount) {
-        this.viewCount += viewCount;
-        this.likeCount += likeCount;
+        super(planPostId);
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostScrap.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/PlanPostScrap.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.planpost.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.planpost.entity.compositekey.PlanPostScrapId;
 import jakarta.persistence.*;
@@ -7,15 +8,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PlanPostScrap {
-    @EmbeddedId
-    private PlanPostScrapId id;
-
+public class PlanPostScrap extends AbstractAssociationEntity<PlanPostScrapId, PlanPost, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("planPostId")
     @JoinColumn(name = "plan_post_id", referencedColumnName = "id", nullable = false)
@@ -26,13 +23,15 @@ public class PlanPostScrap {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(insertable = false, updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public PlanPostScrap(PlanPost planPost, Member member) {
-        this.id = new PlanPostScrapId(planPost.getId(), member.getId());
+        super.initializeId(planPost, member);
         this.planPost = planPost;
         this.member = member;
+    }
+
+    @Override
+    protected PlanPostScrapId createId(PlanPost planPost, Member member) {
+        return new PlanPostScrapId(planPost.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/compositekey/PlanPostLikesId.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/compositekey/PlanPostLikesId.java
@@ -3,12 +3,14 @@ package com.prgrmsfinal.skypedia.planpost.entity.compositekey;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
+import java.io.Serializable;
+
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class PlanPostLikesId {
+public class PlanPostLikesId implements Serializable {
     private Long planPostId;
 
     private Long memberId;

--- a/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/compositekey/PlanPostScrapId.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/planpost/entity/compositekey/PlanPostScrapId.java
@@ -3,12 +3,14 @@ package com.prgrmsfinal.skypedia.planpost.entity.compositekey;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
+import java.io.Serializable;
+
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class PlanPostScrapId {
+public class PlanPostScrapId implements Serializable {
     private Long planPostId;
 
     private Long memberId;

--- a/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostLikes.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostLikes.java
@@ -1,6 +1,6 @@
 package com.prgrmsfinal.skypedia.post.entity;
 
-import java.time.LocalDateTime;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.post.entity.compositekey.PostLikesId;
 import jakarta.persistence.*;
@@ -9,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PostLikes {
-	@EmbeddedId
-	private PostLikesId id;
-
+public class PostLikes extends AbstractAssociationEntity<PostLikesId, Post, Member> {
 	@ManyToOne(cascade = CascadeType.REMOVE)
 	@MapsId("postId")
 	@JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class PostLikes {
 	@JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
 	private Member member;
 
-	@Column(nullable = false, insertable = false, updatable = false)
-	private LocalDateTime createdAt;
-
 	@Builder
 	public PostLikes(Post post, Member member) {
-		this.id = new PostLikesId(post.getId(), member.getId());
+		super.initializeId(post, member);
 		this.post = post;
 		this.member = member;
+	}
+
+	@Override
+	protected PostLikesId createId(Post post, Member member) {
+		return new PostLikesId(post.getId(), member.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostMetrics.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostMetrics.java
@@ -1,33 +1,13 @@
 package com.prgrmsfinal.skypedia.post.entity;
 
-import jakarta.persistence.*;
-import lombok.AccessLevel;
+import com.prgrmsfinal.skypedia.global.entity.AbstractMetricsEntity;
+import jakarta.persistence.Entity;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
-public class PostMetrics {
-    @Id
-    private Long postId;
-
-    @Column(nullable = false)
-    private Long viewCount;
-
-    @Column(nullable = false)
-    private Long likeCount;
-
+public class PostMetrics extends AbstractMetricsEntity {
     @Builder
-    public PostMetrics(Long postId, Long viewCount, Long likeCount) {
-        this.postId = postId;
-        this.viewCount = 0L;
-        this.likeCount = 0L;
-    }
-
-    public void refresh(Long viewCount, Long likeCount) {
-        this.viewCount += viewCount;
-        this.likeCount += likeCount;
+    public PostMetrics(Long postId) {
+        super(postId);
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostScrap.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/entity/PostScrap.java
@@ -1,6 +1,6 @@
 package com.prgrmsfinal.skypedia.post.entity;
 
-import java.time.LocalDateTime;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.post.entity.compositekey.PostScrapId;
 import jakarta.persistence.*;
@@ -9,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PostScrap {
-	@EmbeddedId
-	private PostScrapId id;
-
+public class PostScrap extends AbstractAssociationEntity<PostScrapId, Post, Member> {
 	@ManyToOne(cascade = CascadeType.REMOVE)
 	@MapsId("postId")
 	@JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class PostScrap {
 	@JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
 	private Member member;
 
-	@Column(insertable = false, updatable = false, nullable = false)
-	private LocalDateTime createdAt;
-
 	@Builder
 	public PostScrap(Post post, Member member) {
-		this.id = new PostScrapId(post.getId(), member.getId());
+		super.initializeId(post, member);
 		this.post = post;
 		this.member = member;
+	}
+
+	@Override
+	protected PostScrapId createId(Post post, Member member) {
+		return new PostScrapId(post.getId(), member.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyLikes.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyLikes.java
@@ -1,6 +1,6 @@
 package com.prgrmsfinal.skypedia.reply.entity;
 
-import java.time.LocalDateTime;
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.reply.entity.compositekey.ReplyLikesId;
 import jakarta.persistence.*;
@@ -9,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ReplyLikes {
-	@EmbeddedId
-	private ReplyLikesId id;
-
+public class ReplyLikes extends AbstractAssociationEntity<ReplyLikesId, Reply, Member> {
 	@ManyToOne(cascade = CascadeType.REMOVE)
 	@MapsId("replyId")
 	@JoinColumn(name = "reply_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class ReplyLikes {
 	@JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
 	private Member member;
 
-	@Column(insertable = false, updatable = false, nullable = false)
-	private LocalDateTime createdAt;
-
 	@Builder
 	public ReplyLikes(Reply reply, Member member) {
-		this.id = new ReplyLikesId(reply.getId(), member.getId());
+		super.initializeId(reply, member);
 		this.reply = reply;
 		this.member = member;
+	}
+
+	@Override
+	protected ReplyLikesId createId(Reply reply, Member member) {
+		return new ReplyLikesId(reply.getId(), member.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyPlanPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyPlanPost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.reply.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.planpost.entity.PlanPost;
 import com.prgrmsfinal.skypedia.reply.entity.compositekey.ReplyPlanPostId;
 import jakarta.persistence.*;
@@ -8,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ReplyPlanPost {
-	@EmbeddedId
-	private ReplyPlanPostId id;
-
+public class ReplyPlanPost extends AbstractAssociationEntity<ReplyPlanPostId, Reply, PlanPost> {
 	@ManyToOne
 	@MapsId("replyId")
 	@JoinColumn(name = "reply_id", referencedColumnName = "id", nullable = false)
@@ -24,8 +22,13 @@ public class ReplyPlanPost {
 
 	@Builder
 	public ReplyPlanPost(Reply reply, PlanPost planPost) {
-		this.id = new ReplyPlanPostId(reply.getId(), planPost.getId());
+		super.initializeId(reply, planPost);
 		this.reply = reply;
 		this.planPost = planPost;
+	}
+
+	@Override
+	protected ReplyPlanPostId createId(Reply reply, PlanPost planPost) {
+		return new ReplyPlanPostId(reply.getId(), planPost.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyPost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyPost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.reply.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.post.entity.Post;
 import com.prgrmsfinal.skypedia.reply.entity.compositekey.ReplyLikesId;
 import jakarta.persistence.*;
@@ -8,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ReplyPost {
-	@EmbeddedId
-	private ReplyLikesId id;
-
+public class ReplyPost extends AbstractAssociationEntity<ReplyLikesId, Reply, Post> {
 	@ManyToOne
 	@MapsId("replyId")
 	@JoinColumn(name = "reply_id", referencedColumnName = "id", nullable = false)
@@ -24,8 +22,13 @@ public class ReplyPost {
 
 	@Builder
 	public ReplyPost(Reply reply, Post post) {
-		this.id = new ReplyLikesId(reply.getId(), post.getId());
+		super.initializeId(reply, post);
 		this.reply = reply;
 		this.post = post;
+	}
+
+	@Override
+	protected ReplyLikesId createId(Reply reply, Post post) {
+		return new ReplyLikesId(reply.getId(), post.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyVotePost.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/reply/entity/ReplyVotePost.java
@@ -1,5 +1,6 @@
 package com.prgrmsfinal.skypedia.reply.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.reply.entity.compositekey.ReplyLikesId;
 import com.prgrmsfinal.skypedia.votepost.entity.VotePost;
 import jakarta.persistence.*;
@@ -8,10 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ReplyVotePost {
-	@EmbeddedId
-	private ReplyLikesId id;
-
+public class ReplyVotePost extends AbstractAssociationEntity<ReplyLikesId, Reply, VotePost> {
 	@ManyToOne
 	@MapsId("replyId")
 	@JoinColumn(name = "reply_id", referencedColumnName = "id", nullable = false)
@@ -24,8 +22,13 @@ public class ReplyVotePost {
 
 	@Builder
 	public ReplyVotePost(Reply reply, VotePost votePost) {
-		this.id = new ReplyLikesId(reply.getId(), votePost.getId());
+		super.initializeId(reply, votePost);
 		this.reply = reply;
 		this.votePost = votePost;
+	}
+
+	@Override
+	protected ReplyLikesId createId(Reply reply, VotePost votePost) {
+		return new ReplyLikesId(reply.getId(), votePost.getId());
 	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostItemLikes.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostItemLikes.java
@@ -1,18 +1,15 @@
 package com.prgrmsfinal.skypedia.votepost.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.votepost.entity.compositekey.VotePostItemLikesId;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class VotePostItemLikes {
-    @EmbeddedId
-    private VotePostItemLikesId id;
-
+public class VotePostItemLikes extends AbstractAssociationEntity<VotePostItemLikesId, VotePostItem, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("votePostItemId")
     @JoinColumn(name = "vote_post_item_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class VotePostItemLikes {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(nullable = false, insertable = false, updatable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public VotePostItemLikes(VotePostItem votePostItem, Member member) {
-        this.id = new VotePostItemLikesId(votePostItem.getId(), member.getId());
+        super.initializeId(votePostItem, member);
         this.votePostItem = votePostItem;
         this.member = member;
+    }
+
+    @Override
+    protected VotePostItemLikesId createId(VotePostItem votePostItem, Member member) {
+        return new VotePostItemLikesId(votePostItem.getId(), member.getId());
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostMetrics.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostMetrics.java
@@ -1,35 +1,13 @@
 package com.prgrmsfinal.skypedia.votepost.entity;
 
-import jakarta.persistence.Column;
+import com.prgrmsfinal.skypedia.global.entity.AbstractMetricsEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
-public class VotePostMetrics {
-    @Id
-    private Long votePostId;
-
-    @Column(nullable = false)
-    private Long viewCount;
-
-    @Column(nullable = false)
-    private Long likeCount;
-
+public class VotePostMetrics extends AbstractMetricsEntity {
     @Builder
     public VotePostMetrics(Long votePostId) {
-        this.votePostId = votePostId;
-        this.viewCount = 0L;
-        this.likeCount = 0L;
-    }
-
-    public void refresh(Long viewCount, Long likeCount) {
-        this.viewCount += viewCount;
-        this.likeCount += likeCount;
+        super(votePostId);
     }
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostScrap.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/votepost/entity/VotePostScrap.java
@@ -1,18 +1,15 @@
 package com.prgrmsfinal.skypedia.votepost.entity;
 
+import com.prgrmsfinal.skypedia.global.entity.AbstractAssociationEntity;
 import com.prgrmsfinal.skypedia.member.entity.Member;
 import com.prgrmsfinal.skypedia.votepost.entity.compositekey.VotePostScrapId;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class VotePostScrap {
-    @EmbeddedId
-    private VotePostScrapId id;
-
+public class VotePostScrap extends AbstractAssociationEntity<VotePostScrapId, VotePost, Member> {
     @ManyToOne(cascade = CascadeType.REMOVE)
     @MapsId("votePostId")
     @JoinColumn(name = "vote_post_id", referencedColumnName = "id", nullable = false)
@@ -23,13 +20,15 @@ public class VotePostScrap {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(nullable = false, insertable = false, updatable = false)
-    private LocalDateTime createdAt;
-
     @Builder
     public VotePostScrap(VotePost votePost, Member member) {
-        this.id = new VotePostScrapId(votePost.getId(), member.getId());
+        super.initializeId(votePost, member);
         this.votePost = votePost;
         this.member = member;
+    }
+
+    @Override
+    protected VotePostScrapId createId(VotePost votePost, Member member) {
+        return new VotePostScrapId(votePost.getId(), member.getId());
     }
 }


### PR DESCRIPTION
#### Description

연결 및 통계 엔티티에서 지나치게 중복되는 코드가 많이 보여 추상화 작업을 진행했습니다.

- 연결 엔티티는 AbstractAssociationEntity를 상속.
- 통계 엔티티는 AbstractMetricsEntity를 상속.
- FK의 경우 Cascade 옵션에서 차이를 보이므로 추상화에서 제외.
- 통계 엔티티는 테이블 구조가 일치하므로 추가 구현하지 않음.

#### Reference

중복되는 코드를 1차적으로 제거했으며, 추가적인 추상화 작업을 수행할 경우, Reissue할 예정입니다.